### PR TITLE
chore: pin github actions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,17 +27,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
-          target: aarch64-unknown-linux-gnu
-          override: true
+          targets: aarch64-unknown-linux-gnu
 
       - name: Cache Zig
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.zig
@@ -52,7 +51,7 @@ jobs:
           echo "$PWD/zig-linux-x86_64-0.13.0" >> $GITHUB_PATH
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -99,19 +98,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
-          target: aarch64-unknown-linux-gnu
-          override: true
+          targets: aarch64-unknown-linux-gnu
 
       - name: Cache Zig
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.zig
@@ -126,7 +124,7 @@ jobs:
           echo "$PWD/zig-linux-x86_64-0.13.0" >> $GITHUB_PATH
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -154,7 +152,7 @@ jobs:
           cd ../../..
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: target/lambda/lambda_http_geolocation/lambda_http_geolocation.zip
           tag_name: v${{ github.run_number }}


### PR DESCRIPTION
## Summary
- SHA-pin marketplace actions in `deploy.yml` to current latest
- Replace abandoned `actions-rs/toolchain` with `dtolnay/rust-toolchain` (Rust repos)
- Add Dependabot for the `github-actions` ecosystem (weekly)

## Test plan
- [ ] Validate job passes on the PR
- [ ] Hygiene workflows (commitmsg-conform, markdown-lint) still pass